### PR TITLE
Update URL of IntelliJ Tezos plugin

### DIFF
--- a/src/content/resources-tools.md
+++ b/src/content/resources-tools.md
@@ -6,7 +6,7 @@ title: Tools
 maxContent: -1
 resources:
   - title: Tezos - intellij
-    link: https://www.plugin-dev.com/intellij/
+    link: https://www.plugin-dev.com/plugins/tezos-michelson/
     description: Michelson Plugin for IntelliJ
   - title: Michelson emacs mode
     link: https://github.com/tezos/tezos/tree/master/emacs


### PR DESCRIPTION
Updated the URL to point to the documentation instead of an overview page.