### PR TITLE
Adding TezosJ library to Tezos.developers website

### DIFF
--- a/src/content/getting-started-3.md
+++ b/src/content/getting-started-3.md
@@ -20,4 +20,8 @@ tutorials:
     link: https://github.com/DefinitelyNotAGoat/go-tezos
   - title: AirGap-Coin-Lib
     link: https://github.com/airgap-it/airgap-coin-lib
+  - title: TezosJ_SDK (Android)
+    link: https://github.com/TezosRio/TezosJ_SDK
+  - title: TezosJ_plainJava (Java)
+    link: https://github.com/TezosRio/TezosJ_plainJava
 ---


### PR DESCRIPTION
Dear friends, I think that TezosJ, from Tezos.Rio (which I'm part of), plays an important role in Tezos ecosystem and is also a project that have been awarded with a Foundation grant and there are exchanges that use it. Please, consider letting TezosJ figure on your site. Thanks in advance, Luiz Milfont.