### PR TITLE
Replace Morley with Indigo and add its tutorial

### DIFF
--- a/src/content/getting-started-2.md
+++ b/src/content/getting-started-2.md
@@ -10,9 +10,9 @@ languages:
   - title: SmartPy
     preTitleText: Python
     link: http://smartpy.io/
-  - title: Morley/Lorentz
+  - title: Indigo
     preTitleText: Haskell
-    link: http://hackage.haskell.org/package/morley
+    link: https://indigo-lang.gitlab.io
   - title: Archetype
     preTitleText: Domain-Specific
     link: http://archetype-lang.org/

--- a/src/content/getting-started-3.md
+++ b/src/content/getting-started-3.md
@@ -32,4 +32,6 @@ tutorials:
     link: https://github.com/baking-bad/netezos
   - title: KotlinTezos (Android)
     link: https://gitlab.com/camlcase-dev/kotlin-tezos
+  - title: Morley
+    link: https://gitlab.com/morley-framework/morley
 ---


### PR DESCRIPTION
Replaces Morley/Lorentz with Indigo (which is part of the same project) in the second "Getting Started" column.

Adds its tutorial in the first one.

Adds `Morley` as a library in the third one.